### PR TITLE
fixes "for Unknown" for linux users

### DIFF
--- a/src/components/direct-download-button.js
+++ b/src/components/direct-download-button.js
@@ -8,6 +8,8 @@ const LINKS = {
       'https://updates.insomnia.rest/downloads/mac/latest?app=com.insomnia.app',
     win:
       'https://updates.insomnia.rest/downloads/windows/latest?app=com.insomnia.app',
+    linux:
+      'https://updates.insomnia.rest/downloads/ubuntu/latest?app=com.insomnia.app',
     other: '/download/core/?'
   },
   'com.insomnia.designer': {
@@ -15,6 +17,8 @@ const LINKS = {
       'https://updates.insomnia.rest/downloads/mac/latest?app=com.insomnia.designer',
     win:
       'https://updates.insomnia.rest/downloads/windows/latest?app=com.insomnia.designer',
+    linux:
+      'https://updates.insomnia.rest/downloads/ubuntu/latest?app=com.insomnia.app',
     other: '/download/designer/?'
   }
 };
@@ -55,6 +59,9 @@ class DirectDownloadButton extends React.Component {
     } else if (platform.indexOf('win') !== -1) {
       download.platformName = 'Windows';
       download.link = LINKS[app].win;
+    } else if (platform.indexOf('linux') !== -1 {
+      download.platformName = "Ubuntu";
+      download.link = LINKS[app].linux;
     } else {
       download.platformName = 'Unknown';
       download.link = LINKS[app].other;


### PR DESCRIPTION
I noticed that when downloading Insomnia it says `Insomnia Core for Unknown`, despite `navigator.platform` correctly identifying my platform (Linux).

![Screenshot_20201027_151745](https://user-images.githubusercontent.com/15232461/97350996-91b21f80-1867-11eb-95b9-9620e73de356.png)

I just took a quick peek + edit on GitHub to demonstrate what I'm talking about and what a potential fix might roughly look like.