### PR TITLE
Update brew command to install on macos

### DIFF
--- a/src/pages/download/core.js
+++ b/src/pages/download/core.js
@@ -71,7 +71,7 @@ export default class extends React.Component {
                   <p
                     className="subtle small"
                     style={{ maxWidth: '12rem', margin: 'auto' }}>
-                    or <code>brew cask install insomnia</code>
+                    or <code>brew install insomnia</code>
                   </p>
                 </div>
                 <div className="col-4 platform-download padding-bottom">

--- a/src/pages/download/designer.js
+++ b/src/pages/download/designer.js
@@ -68,7 +68,7 @@ export default class extends React.Component {
                   <p
                     className="subtle small"
                     style={{ maxWidth: '12rem', margin: 'auto' }}>
-                    or <code>brew cask install insomnia-designer</code>
+                    or <code>brew install insomnia-designer</code>
                   </p>
                 </div>
                 <div className="col-4 platform-download padding-bottom">


### PR DESCRIPTION
The command `brew cask install ....` is deprecated and on most newer versions also disabled.
The recommended new command is `brew install ...`